### PR TITLE
92 dicom write with output dir = multi fails in filenameformattag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!--next-version-placeholder-->
 
+## [v3.5.1-rc0] - 2024-04-08
+### Fixed
+* Corrected behaviour when writing 4D DICOM with output_dir == 'multi'.
+
 ## [v3.5.0] - 2024-02-29
 * Modified file name generation to allow user to specify single file output when the format plugin support this.
 

--- a/src/imagedata/formats/dicomplugin.py
+++ b/src/imagedata/formats/dicomplugin.py
@@ -1095,7 +1095,7 @@ class DICOMPlugin(AbstractPlugin):
                     input_order_to_dirname_str(si.input_order),
                     digits)
                 archive.set_member_naming_scheme(
-                    fallback=os.path.join(dirn, 'Image_{:05d}.dcm'),
+                    fallback=os.path.join(dirn, 'Image_{1:05d}.dcm'),
                     level=max(0, si.ndim-2),
                     default_extension='.dcm',
                     extensions=self.extensions
@@ -1131,7 +1131,7 @@ class DICOMPlugin(AbstractPlugin):
                 dirn = "slice{{0:0{0}}}".format(
                     digits)
                 archive.set_member_naming_scheme(
-                    fallback=os.path.join(dirn, 'Image_{:05d}.dcm'),
+                    fallback=os.path.join(dirn, 'Image_{1:05d}.dcm'),
                     level=max(0, si.ndim-2),
                     default_extension='.dcm',
                     extensions=self.extensions

--- a/tests/test_formats_dicom.py
+++ b/tests/test_formats_dicom.py
@@ -316,14 +316,34 @@ class TestDicomPlugin(unittest.TestCase):
         self.assertEqual(newsi.dtype, np.uint16)
         self.assertEqual(newsi.shape, (3, 3, 192, 152))
 
-    def test_write_dicom_4D_multi(self):
+    def test_write_dicom_4D_multi_slice(self):
         si = Series(
             os.path.join('data', 'dicom', 'time_all'),
             formats.INPUT_ORDER_TIME,
             self.opts)
         self.assertEqual('dicom', si.input_format)
         with tempfile.TemporaryDirectory() as d:
-            si.write(d, opts={'output_dir': 'multi'})
+            si.write(d, opts={
+                'output_dir': 'multi',
+                'output_sort': formats.SORT_ON_SLICE
+            })
+            newsi = Series(d, formats.INPUT_ORDER_TIME)
+        self.assertEqual('dicom', newsi.input_format)
+        self.assertEqual(si.shape, newsi.shape)
+        np.testing.assert_array_equal(si, newsi)
+        compare_headers(self, si, newsi)
+
+    def test_write_dicom_4D_multi_tag(self):
+        si = Series(
+            os.path.join('data', 'dicom', 'time_all'),
+            formats.INPUT_ORDER_TIME,
+            self.opts)
+        self.assertEqual('dicom', si.input_format)
+        with tempfile.TemporaryDirectory() as d:
+            si.write(d, opts={
+                'output_dir': 'multi',
+                'output_sort': formats.SORT_ON_TAG
+            })
             newsi = Series(d, formats.INPUT_ORDER_TIME)
         self.assertEqual('dicom', newsi.input_format)
         self.assertEqual(si.shape, newsi.shape)

--- a/tests/test_formats_dicom.py
+++ b/tests/test_formats_dicom.py
@@ -316,6 +316,20 @@ class TestDicomPlugin(unittest.TestCase):
         self.assertEqual(newsi.dtype, np.uint16)
         self.assertEqual(newsi.shape, (3, 3, 192, 152))
 
+    def test_write_dicom_4D_multi(self):
+        si = Series(
+            os.path.join('data', 'dicom', 'time_all'),
+            formats.INPUT_ORDER_TIME,
+            self.opts)
+        self.assertEqual('dicom', si.input_format)
+        with tempfile.TemporaryDirectory() as d:
+            si.write(d, opts={'output_dir': 'multi'})
+            newsi = Series(d, formats.INPUT_ORDER_TIME)
+        self.assertEqual('dicom', newsi.input_format)
+        self.assertEqual(si.shape, newsi.shape)
+        np.testing.assert_array_equal(si, newsi)
+        compare_headers(self, si, newsi)
+
     def test_write_float(self):
         si = Series(np.arange(8*8*8).reshape((8, 8, 8)))
         si.seriesNumber = 100

--- a/tests/test_formats_dicom.py
+++ b/tests/test_formats_dicom.py
@@ -33,7 +33,6 @@ class TestDicomPlugin(unittest.TestCase):
 
     # @unittest.skip("skipping test_read_single_file")
     def test_read_single_file(self):
-        ea
         si1 = Series(
             os.path.join('data', 'dicom', 'time', 'time00', 'Image_00020.dcm'),
             'none',
@@ -156,7 +155,8 @@ class TestDicomPlugin(unittest.TestCase):
             self.opts)
         self.assertEqual('dicom', si1.input_format)
         with tempfile.TemporaryDirectory() as d:
-            si1.write(d, formats=['dicom'], opts={'keep_uid': True})
+            si1.write(os.path.join(d, 'Image_00000.dcm'),
+                      formats=['dicom'], opts={'keep_uid': True})
 
             # Use pydicom as truth to verify that written copy is identical to original
             orig = pydicom.filereader.dcmread(
@@ -255,7 +255,8 @@ class TestDicomPlugin(unittest.TestCase):
         )
         self.assertEqual('dicom', si1.input_format)
         with tempfile.TemporaryDirectory() as d:
-            si1.write('{}?Image.dcm'.format(d), formats=['dicom'])
+            si1.write(os.path.join(d, 'Image.dcm'),
+                      formats=['dicom'])
             si2 = Series(d)
         self.assertEqual('dicom', si2.input_format)
         self.assertEqual(si1.dtype, si2.dtype)
@@ -266,7 +267,8 @@ class TestDicomPlugin(unittest.TestCase):
         si1 = Series(os.path.join('data', 'dicom', 'time', 'time00'))
         self.assertEqual('dicom', si1.input_format)
         with tempfile.TemporaryDirectory() as d:
-            si1.write('{}?Image%05d.dcm'.format(d), formats=['dicom'])
+            si1.write(os.path.join(d, 'Image%05d.dcm'),
+                      formats=['dicom'])
             si2 = Series(d)
         self.assertEqual('dicom', si2.input_format)
         self.assertEqual(si1.dtype, si2.dtype)
@@ -316,7 +318,6 @@ class TestDicomPlugin(unittest.TestCase):
         self.assertEqual(newsi.shape, (3, 3, 192, 152))
 
     def test_write_dicom_4D_multi_slice(self):
-        ea
         si = Series(
             os.path.join('data', 'dicom', 'time_all'),
             formats.INPUT_ORDER_TIME,
@@ -390,7 +391,7 @@ class TestDicomPlugin(unittest.TestCase):
                     si1.SOPInstanceUIDs[(_tag, _slice)]
                     # si1.getDicomAttribute('SOPInstanceUID', slice=_slice, tag=_tag)
         with tempfile.TemporaryDirectory() as d:
-            si1.write('{}?Image%05d.dcm'.format(d),
+            si1.write(os.path.join(d, 'Image%05d.dcm'),
                       formats=['dicom'],
                       opts={'keep_uid': True})
             si2 = Series(d)
@@ -427,7 +428,7 @@ class TestDicomPlugin(unittest.TestCase):
                 si1_sopinsuid[_slice][_tag] =\
                     si1.SOPInstanceUIDs[(_tag, _slice)]
         with tempfile.TemporaryDirectory() as d:
-            si1.write('{}?Image%05d.dcm'.format(d),
+            si1.write(os.path.join(d, 'Image%05d.dcm'),
                       formats=['dicom'],
                       opts={'keep_uid': False})
             si2 = Series(d)
@@ -771,7 +772,7 @@ class TestDicomSlicing(unittest.TestCase):
         np.testing.assert_array_equal(si2.tags[0], si1.tags[0][1:3])
 
 
-class TestDicomPlugin(unittest.TestCase):
+class TestDicomPluginSortCriteria(unittest.TestCase):
     def setUp(self):
         parser = argparse.ArgumentParser()
         cmdline.add_argparse_options(parser)

--- a/tests/test_formats_dicom.py
+++ b/tests/test_formats_dicom.py
@@ -317,6 +317,7 @@ class TestDicomPlugin(unittest.TestCase):
         self.assertEqual(newsi.shape, (3, 3, 192, 152))
 
     def test_write_dicom_4D_multi_slice(self):
+        ea
         si = Series(
             os.path.join('data', 'dicom', 'time_all'),
             formats.INPUT_ORDER_TIME,

--- a/tests/test_formats_dicom.py
+++ b/tests/test_formats_dicom.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import unittest
 import math
 import os.path
@@ -35,6 +33,7 @@ class TestDicomPlugin(unittest.TestCase):
 
     # @unittest.skip("skipping test_read_single_file")
     def test_read_single_file(self):
+        ea
         si1 = Series(
             os.path.join('data', 'dicom', 'time', 'time00', 'Image_00020.dcm'),
             'none',

--- a/tests/test_transport_dicomtransport.py
+++ b/tests/test_transport_dicomtransport.py
@@ -112,7 +112,6 @@ class TestDicomTransport(unittest.TestCase):
 
     # @unittest.skip("skipping test_transport_single_image")
     def test_transport_single_image(self):
-        ea
         si1 = Series(
             os.path.join('data', 'dicom', 'time', 'time00', 'Image_00020.dcm')
         )

--- a/tests/test_transport_dicomtransport.py
+++ b/tests/test_transport_dicomtransport.py
@@ -112,6 +112,7 @@ class TestDicomTransport(unittest.TestCase):
 
     # @unittest.skip("skipping test_transport_single_image")
     def test_transport_single_image(self):
+        ea
         si1 = Series(
             os.path.join('data', 'dicom', 'time', 'time00', 'Image_00020.dcm')
         )


### PR DESCRIPTION
Corrected behaviour in DicomPlugin when writing 4D datasets with output_dir == 'multi'